### PR TITLE
feat: Ajout d'un bouton pour accéder à la fiche FCE d'un établissement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Ce serveur front-end s'appuie sur:
 - Keycloak (pour l'identification des utilisateurs, cf variables d'environnement `VUE_APP_KEYCLOAK_*`)
 - Datapi (pour accéder aux données, cf variable d'environnement `VUE_APP_DATAPI_BASE_URL`)
 
+Guide d'installation: [développement Datapi et frontal en local](https://github.com/signaux-faibles/documentation/blob/master/prise-en-main.md#developpement-datapi-et-frontal-en-local).
+
 ## Project setup
 ```
 yarn install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # signauxfaibles-web
 
+Application web d'exploration des données de Signaux Faibles. Voir [signaux-faibles/documentation](https://github.com/signaux-faibles/documentation) pour plus d'informations.
+
+Ce serveur front-end s'appuie sur:
+- Keycloak (pour l'identification des utilisateurs, cf variables d'environnement `VUE_APP_KEYCLOAK_*`)
+- Datapi (pour accéder aux données, cf variable d'environnement `VUE_APP_DATAPI_BASE_URL`)
+
 ## Project setup
 ```
 yarn install
@@ -15,22 +21,17 @@ yarn run serve
 yarn run build
 ```
 
-### Run your tests
-```
-yarn run test
-```
-
 ### Lints and fixes files
 ```
 yarn run lint
 ```
 
-### Run your end-to-end tests
+### Run your end-to-end tests (TODO)
 ```
 yarn run test:e2e
 ```
 
-### Run your unit tests
+### Run your unit tests (TODO)
 ```
 yarn run test:unit
 ```

--- a/src/components/Etablissement.vue
+++ b/src/components/Etablissement.vue
@@ -8,7 +8,7 @@
           md6
           class="pa-3"
           style="font-size: 18px; margin-top: 3em;">
-            <Identite :historique="historique" :sirene="sirene" :siret="siret" :naf="naf"/>
+            <Identite :historique="historique" :sirene="sirene" :siret="siret" :naf="naf" :lienVisiteFCE="lienVisiteFCE"/>
           </v-flex>
 
           <v-flex xs12 md6 class="text-xs-right pa-3" style="margin-top: 3em">
@@ -55,6 +55,7 @@ export default {
   components: { Effectif, Urssaf, Help, OldFinance, Identite, Map, Commentaire },
   data() {
     return {
+      lienVisiteFCE: null,
       axios: axios.create(),
       sirene: {},
       etablissement: { value: {} },
@@ -281,6 +282,24 @@ export default {
         this.sirene = r.data.etablissement
       }).catch((error) => {
         // this.etablissement = { value: {} }
+      })
+
+      this.axios.post('https://dgefp.opendatasoft.com/api/records/1.0/search/', {
+        'dataset': 'fce-visites',
+        'facet': 'siret',
+        'refine.siret': this.siret,
+      }, {
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Apikey ${ process.env.VUE_APP_FCE_API_KEY }',
+        },
+      })
+      .then((r) => {
+        if (r.data.nhits > 0) {
+          this.lienVisiteFCE = `https://fce.fabrique.social.gouv.fr/establishment/${this.siret}#direccte`
+        }
+      }).catch((error) => {
+        this.lienVisiteFCE = `#dummy` // TODO: remove this, when we do get access to the API
       })
 
     },

--- a/src/components/Etablissement/Identite.vue
+++ b/src/components/Etablissement/Identite.vue
@@ -13,20 +13,20 @@
     <h3>siren {{ siret.slice(0,9) }} <span style="color: #999">{{ siret.slice(9,14) }} siret</span></h3>
     <hr style="color: #eee;"/>
     <div style="padding: 10px; margin: 4px;">
-    
-    <div style="font-size: 16px">{{ (naf.n1 || {})[((naf.n5to1 || {})[(sirene.activite_principale || '')] || '')] }}<br/>
-    {{ (naf.n5 || {})[(sirene.activite_principale || '')] }}<br/>
-    Code APE: {{ (sirene.activite_principale || '') }}</div>
+      <div style="font-size: 16px">
+        {{ (naf.n1 || {})[((naf.n5to1 || {})[(sirene.activite_principale || '')] || '')] }}<br/>
+        {{ (naf.n5 || {})[(sirene.activite_principale || '')] }}<br/>
+        Code APE: {{ (sirene.activite_principale || '') }}<br/>
+        <p v-if="lienVisiteFCE">
+          Cet établissement a fait l'objet d'une visite. 
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            :href="lienVisiteFCE"
+          >Consulter Fiche Commune Entreprise</a>
+        </p>
+      </div>
     </div>
-
-    <p>
-      Cet établissement a fait l'objet d'une visite. 
-      <a
-        target="_blank"
-        rel="noopener noreferrer"
-        :href="fceURL"
-      >Consulter Fiche Commune Entreprise</a>
-    </p>
     
     <h3>adresse postale</h3>
     <hr style="color: #eee;"/>
@@ -48,12 +48,7 @@ import Historique from '@/components/Etablissement/Historique.vue'
 
 export default {
   name: 'Identite',
-  props: ['sirene', 'historique', 'siret', 'naf'],
+  props: ['sirene', 'historique', 'siret', 'naf', 'lienVisiteFCE'],
   components: { Help, Historique },
-  computed: {
-    fceURL() {
-      return `https://fce.fabrique.social.gouv.fr/establishment/${this.siret}#direccte`
-    },
-  },
 }
 </script>

--- a/src/components/Etablissement/Identite.vue
+++ b/src/components/Etablissement/Identite.vue
@@ -18,6 +18,15 @@
     {{ (naf.n5 || {})[(sirene.activite_principale || '')] }}<br/>
     Code APE: {{ (sirene.activite_principale || '') }}</div>
     </div>
+
+    <p>
+      Cet établissement a fait l'objet d'une visite. 
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        :href="fceURL"
+      >Consulter Fiche Commune Entreprise</a>
+    </p>
     
     <h3>adresse postale</h3>
     <hr style="color: #eee;"/>
@@ -41,5 +50,10 @@ export default {
   name: 'Identite',
   props: ['sirene', 'historique', 'siret', 'naf'],
   components: { Help, Historique },
+  computed: {
+    fceURL() {
+      return `https://fce.fabrique.social.gouv.fr/establishment/${this.siret}#direccte`
+    },
+  },
 }
 </script>


### PR DESCRIPTION
## Objectif

Quand un établissement a fait l'objet d'une visite, afficher un lien permettant d'accéder à la fiche FCE correspondante.

## Implémentation

[PROVISOIRE] Appel à l'API de FCE directement depuis l'app web, en attendant que Datapi puisse fourni les données (cf https://github.com/signaux-faibles/datapi/pull/17)

## Rendu

<img width="906" alt="Capture d’écran 2020-08-13 à 14 18 56" src="https://user-images.githubusercontent.com/531781/90133831-70658b00-dd70-11ea-877c-717a35cf7991.png">

## TODO

- [ ] ne pas affecter l'URL dans `this.visiteFCE`, dans le cas où l'appel à l'API échoue.