### PR TITLE
ajustement propriétés NAF

### DIFF
--- a/src/components/Etablissement/Identite.vue
+++ b/src/components/Etablissement/Identite.vue
@@ -49,13 +49,13 @@ export default {
       return (this.sirene || {}).naf || {}
     },
     libelleSecteur() {
-      return this.naf.secteur || ''
+      return this.naf.libelleSecteur || ''
     },
     libelleActivite() {
-      return this.naf.activite || ''
+      return this.naf.libelleactivite || ''
     },
     codeActivite() {
-      return this.naf.n5 || ''
+      return this.naf.codeActivite || ''
     },
   },
 }


### PR DESCRIPTION
# correction des propriétés utilisées pour l'affichage

le type NAF présent dans datapi est désormais comme suit et apporte les libellés des niveaux intermédiaires
```go
		NAF        struct {
			LibelleActivite string `json:"libelleActivite"`
			LibelleSecteur  string `json:"libelleSecteur"`
			CodeSecteur     string `json:"codeSecteur"`
			CodeActivite    string `json:"codeActivite"`
			LibelleN2       string `json:"libelleN2"`
			LibelleN3       string `json:"libelleN3"`
			LibelleN4       string `json:"libelleN4"`
		} `json:"naf"`
```