### PR TITLE
feat/utilisation des permissions datapi dans l'affichage

### DIFF
--- a/src/components/Etablissement.vue
+++ b/src/components/Etablissement.vue
@@ -22,10 +22,10 @@
             <Commentaire :siret="siret" />
           </v-flex>
           <v-flex md6 xs12 class="pr-1" style="min-height: 200px">
-            <Effectif :effectif="effectif" :apconso="apconso" :apdemande="apdemande" />
+            <Effectif :effectif="effectif" :apconso="apconso" :apdemande="apdemande" :permDGEFP="perms.permDGEFP" />
           </v-flex>
           <v-flex md6 xs12 class="pr-1">
-            <Urssaf :debit="debit" :cotisation="cotisation" />
+            <Urssaf :debit="debit" :cotisation="cotisation" :permUrssaf="perms.permUrssaf" />
           </v-flex>
           <v-flex xs12 class="pr-1">
             <Finance :finance="finance" :siret="siret" />
@@ -473,6 +473,15 @@ export default {
     },
     etablissementsSummary() {
       return (this.etablissement.entreprise || {}).etablissementsSummary || []
+    },
+    perms() {
+      const summary = this.etablissementsSummary.filter((s) => s.siret == this.siret)[0] || {}
+      return {
+        permDGEFP: summary.permDGEFP || false,
+        permUrssaf: summary.permUrssaf || false,
+        permScore: summary.permScore || false,
+        permBDF: summary.permBDF || false,
+      }
     },
     groupe() {
       return ((this.etablissement.entreprise || {}).groupe || {}).raison_sociale_groupe

--- a/src/components/Etablissement.vue
+++ b/src/components/Etablissement.vue
@@ -475,7 +475,7 @@ export default {
       return (this.etablissement.entreprise || {}).etablissementsSummary || []
     },
     perms() {
-      const summary = this.etablissementsSummary.filter((s) => s.siret == this.siret)[0] || {}
+      const summary = this.etablissementsSummary.filter((s) => s.siret === this.siret)[0] || {}
       return {
         permDGEFP: summary.permDGEFP || false,
         permUrssaf: summary.permUrssaf || false,

--- a/src/components/Etablissement/Effectif.vue
+++ b/src/components/Etablissement/Effectif.vue
@@ -14,7 +14,7 @@
         <template>
           Ce graphique illustre les données d'emploi.<br/><br/>
           <b>effectifs</b>: Évolution des effectifs en nombre de salariés. (donnée fournie par l'ACOSS)<br/>
-          <div v-if="roles.includes('dgefp')">
+          <div v-if="permDGEFP">
           <b>autorisation d'activité partielle</b>: Nombre de salariés concernés par une autorisation d'activité partielle pour la période représentée. (donnée fournie par la DGEFP)<br/> 
           <b>consommation d'activité partielle</b>: Nombre d'équivalents temps plein mensuel calculé à partir de la somme du nombre d'heures d'activité partielle consommées divisée par la durée légale de 151,67 h. (donnée fournie par la DGEFP)
           </div>

--- a/src/components/Etablissement/Effectif.vue
+++ b/src/components/Etablissement/Effectif.vue
@@ -5,7 +5,7 @@
       color='indigo darken-5'>
       <v-toolbar-title class="localtoolbar">
         Effectifs
-        <span v-if="roles.includes('dgefp')">
+        <span v-if="permDGEFP">
           / Activité partielle
         </span>
       </v-toolbar-title>
@@ -30,7 +30,7 @@ import Help from '@/components/Help.vue'
 
 export default {
   name: 'Effectif',
-  props: ['effectif', 'chart', 'apdemande', 'apconso'],
+  props: ['effectif', 'chart', 'apdemande', 'apconso', 'permDGEFP'],
   components: { Help },
   methods: {
     equivalentTempsPlein(heures) {

--- a/src/components/Etablissement/Historique.vue
+++ b/src/components/Etablissement/Historique.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <h2>
+    <h2 v-if="historique.length > 0">
       Historique des alertes
       <Help titre="Historique des alertes">
         <template>

--- a/src/components/Etablissement/Urssaf.vue
+++ b/src/components/Etablissement/Urssaf.vue
@@ -18,14 +18,14 @@
       </Help>
     </v-toolbar>
     <apexchart
-      v-if="roles.includes('urssaf')"
+      v-if="permUrssaf"
       width="100%"
       heigth="100%"
       type="line"
       :options="options"
       :series="series"
     ></apexchart>
-    <div style=" height: 250px; width: 100%; text-align: center;" v-if="!roles.includes('urssaf')">
+    <div style=" height: 250px; width: 100%; text-align: center;" v-if="!permUrssaf">
       <img
         style="vertical-align: middle; margin: 125px 0; opacity: 0.2;"
         height="100px"
@@ -40,7 +40,7 @@ import Help from '@/components/Help.vue'
 export default {
   name: 'Urssaf',
   components: { Help },
-  props: ['debit', 'cotisation', 'chart'],
+  props: ['debit', 'cotisation', 'chart', 'permUrssaf'],
   computed: {
     series() {
       if ((this.cotisation || []).length > 0 || (this.debit || []).length > 0) {

--- a/src/components/PredictionWidget.vue
+++ b/src/components/PredictionWidget.vue
@@ -29,25 +29,25 @@
           <img
             class="d-block mt-2 mb-2"
             width="70"
-            v-if="!prediction.urssaf && roles.includes('urssaf') && (prediction.alert)"
+            v-if="!prediction.urssaf && permUrssaf"
             src="../assets/gray_urssaf.svg"
           />
           <img
             class="d-block mt-2 mb-2"
             width="70"
-            v-if="prediction.urssaf && roles.includes('urssaf') && (prediction.alert)"
+            v-if="prediction.urssaf && permUrssaf"
             src="../assets/red_urssaf.svg"
           />
           <img
             class="activite-partielle mt-1 mr-1"
             height="24"
-            v-if="prediction.activite_partielle && roles.includes('dgefp') && (prediction.alert) "
+            v-if="prediction.activite_partielle && permDGEFP"
             src="../assets/red_apart.svg"
           />
           <img
             class="activite-partielle mt-1 mr-1"
             height="24"
-            v-if="!prediction.activite_partielle && roles.includes('dgefp') && (prediction.alert)"
+            v-if="!prediction.activite_partielle && permDGEFP"
             src="../assets/gray_apart.svg"
           />
           <span class="effectif">{{ prediction.dernier_effectif || 'n/c' }}</span>
@@ -111,6 +111,12 @@ export default {
         resultat_expl_color: this.prediction.resultat_expl ?
           (this.prediction.resultat_expl < 0 ? 'down' : null) : 'unknown',
       }
+    },
+    permUrssaf() {
+      return this.prediction.permUrssaf || false
+    },
+    permDGEFP() {
+      return this.prediction.permDGEFP || false
     },
   },
   methods: {

--- a/src/components/ScoreWidget.vue
+++ b/src/components/ScoreWidget.vue
@@ -13,7 +13,7 @@
 <script>
 export default {
   name: 'ScoreWidget',
-  props: ['prediction', 'permScore', 'size'],
+  props: ['prediction', 'size'],
   computed: {
     alert() {
       return this.prediction

--- a/src/components/ScoreWidget.vue
+++ b/src/components/ScoreWidget.vue
@@ -22,7 +22,7 @@ export default {
       return this.size || '35px'
     },
     permScore() {
-      return this.prediction.hasOwnProperty('permScore')?this.prediction.permScore:true
+      return this.prediction.hasOwnProperty('permScore') ? this.prediction.permScore : true
     },
     logo() {
       const alerts = {
@@ -41,7 +41,7 @@ export default {
       let probClass = ''
       if (!this.permScore) {
         probClass = 'forbidden'
-      } else if ((this.permScore || true) && alert == null) {
+      } else if (this.permScore && alert == null) {
         probClass = 'absent'
       } else if (alert === 'Pas d\'alerte') {
         probClass = 'none'

--- a/src/components/ScoreWidget.vue
+++ b/src/components/ScoreWidget.vue
@@ -1,6 +1,5 @@
 <template>
   <span style="position: relative;">
-   
     <v-icon
       :size="iconSize"
       style="position: relative; right: 1px"
@@ -14,7 +13,7 @@
 <script>
 export default {
   name: 'ScoreWidget',
-  props: ['prediction', 'size'],
+  props: ['prediction', 'permScore', 'size'],
   computed: {
     alert() {
       return this.prediction
@@ -22,12 +21,15 @@ export default {
     iconSize() {
       return this.size || '35px'
     },
+    permScore() {
+      return this.prediction.hasOwnProperty('permScore')?this.prediction.permScore:true
+    },
     logo() {
       const alerts = {
         high: ['fa-exclamation-triangle', 'red accent-2'],
         low: ['fa-exclamation-triangle', 'amber'],
         none: ['fa-check-circle', 'green'],
-        forbidden: ['fa-ban', 'red accent-1'],
+        forbidden: ['fa-lock', '#33333358'],
         absent: ['fa-question-circle', '#33333358'],
       }
       return {
@@ -37,10 +39,10 @@ export default {
     detection() {
       const alert = this.alert.alert
       let probClass = ''
-      if (alert == null && (this.alert.visible || this.alert.followed)) {
-        probClass = 'absent'
-      } else if (alert == null && (!this.alert.visible && !this.alert.followed)) {
+      if (!this.permScore) {
         probClass = 'forbidden'
+      } else if ((this.permScore || true) && alert == null) {
+        probClass = 'absent'
       } else if (alert === 'Pas d\'alerte') {
         probClass = 'none'
       } else if (alert === 'Alerte seuil F2') {


### PR DESCRIPTION
Les objets summaries renvoient maintenant des propriétés qui spécifient les droits d'affichage pour l'établissement concerné:
- Visible: l'entreprise est présente dans la zone géographique de l'utilisateur
- FollowedEntreprise: au moins un établissement de cette entreprise est suivi
- permDGEFP: les données DGEFP sont autorisées
- permUrssaf: idem pour les données Urssaf
- permScore: idem pour les scores et les alertes
- permBDF: idem pour les données BDF (inexistantes pour le moment)

Cette PR remplace les anciens tests de gestion de droits avec ces propriétés pour un affichage plus consistant (en particulier l'affichage faite la différence entre des données URSSAF interdites ou absentes).
Il serait possible à partir de ces propriétés de faire un texte qui explique à l'utilisateur pour quelle raison il voit (ou pas) les informations d'un établissement.

L'affichage du sigle stationnement interdit est remplacé par un cadenas dans les objets PredictionWidget (qui pourrait s'appeler Summary Widget d'ailleurs)