### PR TITLE
fix application figée avec certains paramètres dans le suivi 

### DIFF
--- a/src/views/follow/main.vue
+++ b/src/views/follow/main.vue
@@ -272,7 +272,7 @@
           </v-alert>
         </div>
         <PredictionWidget
-            v-for="e in etablissements.slice(0,100)"
+            v-for="e in uniqEtablissements"
             :key="e.siret"
             :prediction="e"
             @follow-etablissement="getFollowedEtablissements"

--- a/src/views/follow/script.js
+++ b/src/views/follow/script.js
@@ -135,6 +135,13 @@ export default {
     etablissements() {
       return this.followPayload.summaries || []
     },
+    uniqEtablissements() {
+      const map = this.etablissements.reduce((m, e) => {
+        m[e.siret] = e
+        return m
+      }, {})
+      return Object.values(map)
+    },
     params() {
       const params = {}
       params.type = this.type

--- a/src/views/follow/script.js
+++ b/src/views/follow/script.js
@@ -136,6 +136,7 @@ export default {
       return this.followPayload.summaries || []
     },
     uniqEtablissements() {
+      // TODO: déplacer cette logique dans le backend
       const map = this.etablissements.reduce((m, e) => {
         m[e.siret] = e
         return m


### PR DESCRIPTION
Dans certains cas il arrive que le backend renvoie 2 établissements identiques dans le suivi (lorsqu'il y a 2 cartes), cela a pour effet de troubler la sérénité de vuejs parce que 2 élements se mettent à porter la même clé.

Ce correctif s'assure que les summaries affichés sont bien uniques dans le suivi d'établissement